### PR TITLE
add optional support for attr_list extension in mkdocs

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -8,11 +8,11 @@ class Image2FigurePlugin(BasePlugin):
 
     def on_page_markdown(self, markdown, **kwargs):
       
-        pattern = re.compile(r'!\[(.*?)\]\((.*?)\)', flags=re.IGNORECASE)
+        pattern = re.compile(r'!\[(.*?)\]\((.*?)\)\{?([^\}]*)?\}?', flags=re.IGNORECASE)
         
         markdown = re.sub(pattern,
             r'<figure class="figure-image">\n' + \
-            r'  <img src="\2" alt="\1">\n' + \
+            r'  <img src="\2" alt="\1" \3>\n' + \
             r'  <figcaption>\1</figcaption>\n' + \
             r'</figure>',                        
             markdown)            

--- a/tests/fixtures/docs/index.md
+++ b/tests/fixtures/docs/index.md
@@ -3,3 +3,7 @@
 Our image:
 
 ![our image caption](github-octocat.png)
+
+![our image caption](github-octocat.png){ align="left" }
+
+![our image caption](github-octocat.png){ align="right" }

--- a/tests/fixtures/mkdocs.yml
+++ b/tests/fixtures/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: test img2fig page
 
+markdown_extensions:
+    - attr_list
+
 plugins:
     - search
     - img2fig


### PR DESCRIPTION
This is limited to direct attribute support as it will be included
in the <img> tag directly:
{ align="right" class="something" }
becomes:
<img align="right" class="something" />

You cannot use:
{: .class}
as this becomes:
<img : .class />

Signed-off-by: Michael Scott <mike@foundries.io>