### PR TITLE
support {attr} and fix img path error when use_directory_url=True

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 dist/
 *.egg-info/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -2,22 +2,30 @@
 
 This [MkDocs](https://www.mkdocs.org) plugin converts markdown encoded images like
 
-```
-![An image caption](\assets\images\my-image.png)
+```markdown
+![An image caption](../images/my-image.png){align="right" width="20%"}
 ```
 
 into 
 
 ```html
 <figure class="figure-image">
-  <img src="\assets\images\my-image.png" alt="An image caption">
+  <img src="../../images/my-image.png" alt="An image caption" align="left" width="20%" >
   <figcaption>An image caption</figcaption>
 </figure>
 ```
 
+- of course, you could leave out `{align="right" width="20%"}`
+- support attr : https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/img
+- unfortunately, `align:center` is not supported. if you want to center image, use
+
+```markdown
+![An image caption](../images/my-image.png){width="20%" style="display:block; margin:0 auto;"}
+```
+
 ## Requirements
 
-This package requires Python >=3.5 and MkDocs version 1.0 or higher.  
+This package requires Python >=3.6 and MkDocs version 1.0 or higher.  
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author='Antonio Cambule',
     author_email='antonio.cambule@stueber.de',
 	license='MIT',
-	python_requires='>=3.5',
+	python_requires='>=3.6',
     install_requires=[
 		'mkdocs'
 	],

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -2,19 +2,30 @@
 
 import re
 
+from pathlib import Path
 from mkdocs.plugins import BasePlugin
 
-class Image2FigurePlugin(BasePlugin):
 
+def modify_match(match):
+    caption, image_link, attr_list = match.groups()
+    image_link = ('..' / Path(image_link)).as_posix()
+    if attr_list:
+        attr_list = attr_list.replace('{', '').replace('}', '')
+    else:
+        attr_list = ''
+
+    return (
+        r'<figure class="figure-image">'
+        rf'  <img src="{image_link}" alt="{caption}" {attr_list}>'
+        rf'  <figcaption>{caption}</figcaption>'
+        r'</figure>'
+    )
+
+
+class Image2FigurePlugin(BasePlugin):
     def on_page_markdown(self, markdown, **kwargs):
-      
-        pattern = re.compile(r'!\[(.*?)\]\((.*?)\)\{?([^\}]*)?\}?', flags=re.IGNORECASE)
-        
-        markdown = re.sub(pattern,
-            r'<figure class="figure-image">\n' + \
-            r'  <img src="\2" alt="\1" \3>\n' + \
-            r'  <figcaption>\1</figcaption>\n' + \
-            r'</figure>',                        
-            markdown)            
+
+        pattern = re.compile(r'!\[(.*?)\]\((.*?)\)(\{[^\}]*\})?', flags=re.IGNORECASE)
+        markdown = re.sub(pattern, modify_match, markdown)
 
         return markdown

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -8,11 +8,11 @@ class Image2FigurePlugin(BasePlugin):
 
     def on_page_markdown(self, markdown, **kwargs):
       
-        pattern = re.compile(r'!\[(.*?)\]\((.*?)\)', flags=re.IGNORECASE)
+        pattern = re.compile(r'!\[(.*?)\]\((.*?)\)\{?([^\}]*)?\}?', flags=re.IGNORECASE)
         
         markdown = re.sub(pattern,
             r'<figure class="figure-image">\n' + \
-            r'  <img src="\2" alt="\1">\n' + \
+            r'  <img src="\2" alt="\1" \3>\n' + \
             r'  <figcaption>\1</figcaption>\n' + \
             r'</figure>',                        
             markdown)            

--- a/tests/fixtures/docs/index.md
+++ b/tests/fixtures/docs/index.md
@@ -3,3 +3,7 @@
 Our image:
 
 ![our image caption](github-octocat.png)
+
+![our image caption](github-octocat.png){ align="left" }
+
+![our image caption](github-octocat.png){ align="right" }

--- a/tests/fixtures/docs/index.md
+++ b/tests/fixtures/docs/index.md
@@ -2,8 +2,6 @@
 
 Our image:
 
+![attr caption](github-octocat.png){align="right" width="20%"}
+
 ![our image caption](github-octocat.png)
-
-![our image caption](github-octocat.png){ align="left" }
-
-![our image caption](github-octocat.png){ align="right" }

--- a/tests/fixtures/mkdocs.yml
+++ b/tests/fixtures/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: test img2fig page
 
+markdown_extensions:
+    - attr_list
+
 plugins:
     - search
     - img2fig

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -85,4 +85,8 @@ def test_img2fig_output(tmp_path):
     assert os.path.exists(index_file), "%s does not exist" % index_file
 
     contents = pathlib.Path(index_file).read_text()
+    print(contents)
     assert "<figcaption>our image caption</figcaption>" in contents
+    assert '<img src="../github-octocat.png" alt="attr caption" align="right" width="20%">' in contents
+    
+


### PR DESCRIPTION
- support attr_list as promote by @mike-scott  https://github.com/stuebersystems/mkdocs-img2fig-plugin/pull/5, I fix a bug inside his PR and add test
- unfortunately, I don't know how to get `use_directory_url`'s value even I read mkdocs plugin docs....
- so this PR won't work when `use_directory_url=False`